### PR TITLE
fix: Stop block AI gui popup

### DIFF
--- a/calibrate/blockmatch.py
+++ b/calibrate/blockmatch.py
@@ -141,7 +141,7 @@ def find_poi(image):
     # lets remove those!
     rect = shrink_bounding_box(source, block_size, rect)
 
-    draw_and_show(color,rect,(0,255,0))
+    #draw_and_show(color,rect,(0,255,0))
 
     return block_size, rect
 


### PR DESCRIPTION
Oops; in the last PR, a window would popup showing the outline of the rect.
This PR removes that error.