### PR TITLE
Field subrect

### DIFF
--- a/Callibration.py
+++ b/Callibration.py
@@ -178,7 +178,8 @@ class Calibrator:
 
         buttons.addImage(ButtonIndices.CALLIBRATE, images[im_names.C_BOARD], 1724, 600, HYDRANT_SCALE, img2 = images[im_names.C_BOARD2],
                          tooltip = ["Set the bounds for the tetris board. One dot",
-                                    "should be centered along each mino."])
+                                    "should be centered along each mino.",
+                                    "Press 'B' to switch inner bounds"])
         buttons.addImage(ButtonIndices.NEXTBOX, images[im_names.C_NEXT], 2100, 600, HYDRANT_SCALE, img2 = images[im_names.C_NEXT2],
                          tooltip = ["Set the bounds across the active area of the entire",
                                     "next box. Make sure four dots are symmetrically placed",
@@ -680,7 +681,13 @@ class Calibrator:
                 # maxoutclub/regular/precise
                 if self.nextBounds is not None:
                     self.nextBounds.cycle_sub_rect()
-                    print ("Toggled bounds to :", self.nextBounds.sub_rect_name)
+                    print ("Toggled preview bounds to:", self.nextBounds.sub_rect_name)
+            elif event.key == pygame.K_b:
+                # toggle board subrectangle between 
+                # maxoutclub / regular
+                if self.bounds is not None:
+                    self.bounds.cycle_sub_rect()
+                    print ("Toggled board bounds to:", self.bounds.sub_rect_name)
             elif event.key in BoundsPicker.KEYBOARD_KEYS:
                 # numbers 1-9 for board selection
                 if self.boundsManager is not None:

--- a/Callibration.py
+++ b/Callibration.py
@@ -180,6 +180,7 @@ class Calibrator:
                          tooltip = ["Set the bounds for the tetris board. One dot",
                                     "should be centered along each mino.",
                                     "Press 'B' to switch inner bounds"])
+
         buttons.addImage(ButtonIndices.NEXTBOX, images[im_names.C_NEXT], 2100, 600, HYDRANT_SCALE, img2 = images[im_names.C_NEXT2],
                          tooltip = ["Set the bounds across the active area of the entire",
                                     "next box. Make sure four dots are symmetrically placed",
@@ -348,8 +349,11 @@ class Calibrator:
         self.boundsManager = None
         self.bounds = Bounds(False, config=c)
         self.bounds.setRect(board)
+        self.bounds.setSubRect(suggested.inner_box)
         self.bounds.set()
         self.ai_error = None
+        suggested = suggested.preview
+
         pixels, preview_layout = autofindfield.get_next_box(self.frame, board, suggested)
         if pixels is not None:
             self.nextBounds = Bounds(True, config=c)

--- a/Callibration.py
+++ b/Callibration.py
@@ -352,7 +352,6 @@ class Calibrator:
         self.bounds.setSubRect(suggested.inner_box)
         self.bounds.set()
         self.ai_error = None
-        suggested = suggested.preview
 
         pixels, preview_layout = autofindfield.get_next_box(self.frame, board, suggested)
         if pixels is not None:

--- a/calibrate/autofindfield.py
+++ b/calibrate/autofindfield.py
@@ -6,67 +6,27 @@ import numpy as np
 import cv2
 from enum import Enum
 from calibrate.blockmatch import (
-find_piece, calc_new_rect, BLOCKMATCH_SCALE_FACTOR
+find_piece, calc_new_rect, BLOCKMATCH_SCALE_FACTOR,
+auto_level, posterise_image, draw_and_show, show_image,
+convert_to_grayscale, try_expand, NES_BLOCK_PIXELS,
+is_blackish
 )
 
 from calibrate.autolayout import (
 PREVIEW_LAYOUTS, LAYOUTS, PreviewLayout
 )
+
 from calibrate.rect import Rect
 
 NES_PIXELS_BOARD_HEIGHT = 160
 NES_PIXELS_BOARD_WIDTH = 80
-NES_BLOCK_PIXELS = 8
 
-def is_blackish(tuple):
-    return tuple[0] < 20 and tuple[1] < 20 and tuple[2] < 20
+# pixel size for subpixel optimization.
+OPTIMIZE_FIELD_FACTOR = 4
+O_NES_HEIGHT = NES_PIXELS_BOARD_HEIGHT * OPTIMIZE_FIELD_FACTOR 
+O_NES_WIDTH = NES_PIXELS_BOARD_WIDTH * OPTIMIZE_FIELD_FACTOR
 
 
-def try_expand(arr, centre):
-    """
-    flood fills array from centre (y,x)
-    Returns rect class
-    """    
-    not_blackish = not is_blackish(arr[centre[0],centre[1]])
-    if not_blackish:
-        return Rect(centre[1],centre[0],centre[1],centre[0]), None
-
-    arr = np.array(arr, copy=True)
-    red = (0,0,255) #Blue green red
-    
-    centre = centre[1], centre[0] # opencv uses x,y
-    cv2.floodFill(arr, None, centre, newVal=red, loDiff=(5, 5, 5), upDiff=(5, 5, 5))
-
-    #cv2.imshow('color image', arr) 
-    #cv2.waitKey(0)
-    
-    red_px = np.where(np.all(arr == red, axis=-1))
-    
-    y_values = list(red_px[0])
-    y_values.sort()
-    x_values = list(red_px[1])
-    x_values.sort()
-    
-    top, bot = y_values[0], y_values[-1]
-    left, right = x_values[0], x_values[-1]
-    
-    # todo: check percentage of red pixels, it better be at least 50%:
-    # reject if there's an overwhelming amount of non-red
-
-    return (Rect(left, top, right, bot), arr)
-
-def convert_to_grayscale(arr):
-    """
-    converts a BGR (technically RGB works too) image to grayscale RGB,
-    an rgb image where RGB channels are the same and are luminance.
-    """
-    # Convert image to grayscale, but in RGB format
-    gray = cv2.cvtColor(arr, cv2.COLOR_BGR2GRAY)
-    arr = np.zeros_like(arr)
-    arr[:,:,0] = gray
-    arr[:,:,1] = gray
-    arr[:,:,2] = gray
-    return arr
 
 
 import time
@@ -81,13 +41,6 @@ def get_board(img):
 
     size = arr.shape[:2]
     
-    centre = (size[0]//2, size[1]//2) # y, x
-    stencil = (int(size[0] * 563/1080.0), 
-               int(size[1] * 675/1920.0))
-    right_third = (size[0]//2,
-                   int(size[1] * 0.75))
-    
-    
     results = []
     # check each attempt, removing them if the field is way too small or big.
     for attempt in LAYOUTS.values():
@@ -97,25 +50,30 @@ def get_board(img):
         centre[0], centre[1] = int(centre[1]*size[0]), int(centre[0]*size[1]) # end result is y/x
         
         result, temp_image = try_expand(arr, centre)
-        print("potential field:", result)
+        #print("potential field:", result)
         if (result.width < 0.10 * size[1]):
-            print ("Field too skinny, skipping")
+            #print ("Field too skinny, skipping")
             #show_image(temp_image)
             continue
         if (result.height > 0.95 * size[0] or
-           result.height < 0.35 * size[0]):
-            print ("field too tall or short, skipping")
+            result.height < 0.35 * size[0]):
+            #print ("field too tall or short, skipping")
             #show_image(temp_image)
             continue
         # field can't touch top or bottom of screen
         if (result.left < 5 or result.top < 5 or
-           result.right > size[1] -5 or result.bottom > size[0] - 5):
-            print ("field too close to edge of image")
+            result.right > size[1] -5 or result.bottom > size[0] - 5):
+            #print ("field too close to edge of image")
             #show_image(temp_image)
             continue
+
         if result in [r[0] for r in results]:
             continue # duplicate result
-        results.append([result, attempt.preview])
+        
+        layout = attempt.clone()
+        
+        results.append([result, layout, temp_image])
+        
     
     if len(results) == 0:
         print("AI could not find a board")
@@ -128,21 +86,62 @@ def get_board(img):
     # discard any rectangles that are clearly too small
     results = list(filter(lambda x: x[0].area >= 0.98*max_area, results))
     results.sort(key=lambda x:x[0].area, reverse=True)
-    # Convert rects to dumb tuples
+    
     for result in results:
-        result[0] = result[0].to_array()
+        optimize_field(result)
+    
     print("Time taken to ai find fields:", time.time()-t)
-    # we could instead return everything, so that
-    # the user can pick the best one
-    print("final results:", results)
+    
+    # convert to dumb rects
+    results = [(r[0].to_array(), r[1]) for r in results]
     return results
+
+def optimize_field(result):
+    """
+    optimize field in place
+    """
+    rect, layout, image = result
+    # show_image(image)
+    # grab the poi:
+    image = image [rect.top:rect.bottom+1, rect.left:rect.right+1]
+    image[np.all(image == (0,0,255), axis=-1)] = (0,0,0)
+    
+    image = cv2.resize(image, (O_NES_WIDTH, O_NES_HEIGHT))
+    image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    image = auto_level(image)
+    
+    index = 0
+    
+    # slice one nes block worth, from bottom upwards
+    # stop when we see 3+ blocks worth of pixels
+    bottom = O_NES_HEIGHT
+    block_size = NES_BLOCK_PIXELS * OPTIMIZE_FIELD_FACTOR
+    result = None
+    for i in range(0, block_size):
+        slice = image[O_NES_HEIGHT-i-1:O_NES_HEIGHT-i]
+        count = np.count_nonzero((slice >= 2))
+        if count > 2*block_size:
+            result = i
+            break
+    
+    if result is None:
+        print("Unable to optimize MoC vs standard field")
+        return 
+    
+    #convert back to original image scale...
+    nes_px_mult = 1.0 / NES_PIXELS_BOARD_HEIGHT # one nes px to percent
+    inner_box = list(layout.inner_box)
+    result /= float(OPTIMIZE_FIELD_FACTOR) # bring result into nes_px land
+    
+    result *= nes_px_mult # bring result into percent land
+    inner_box[3] = 1.0 - result
+    layout.inner_box = inner_box
 
 
 def get_next_box(img, board_coord, suggested):
     """
     Iterates through all possible next box locations, starting with suggested one.
-    """
-    print(suggested)
+    """    
     layouts = list(PREVIEW_LAYOUTS.values())
     layouts.remove(suggested)
     layouts.insert(0,suggested)
@@ -170,8 +169,6 @@ def get_next_box(img, board_coord, suggested):
         else:
             best_corner = None
             for corner in layout.inner_box_corners_nespx:
-                print (corner, top, nes_pixel_y)
-                print (corner, left, nes_pixel_x)
                 fill_point = [int(top + corner[1] * nes_pixel_y),
                               int(left + corner[0] * nes_pixel_x)]
                 if not (0 <= fill_point[0] <= size[0] and 0 <= fill_point[1] <= size[1]):
@@ -187,7 +184,7 @@ def get_next_box(img, board_coord, suggested):
                 continue
 
             rect, temp_image = try_expand(arr, fill_point)
-            print("Filled:", rect, "w", rect.width,"h",rect.height)
+
 
             # The preview's size should match the reference's size
             # this means it should be roughly 4 Blocks wide and 2 blocks tall
@@ -230,11 +227,11 @@ def check_layout_size_legit(layout, nes_pixel_size, rect, fill_image):
     piece_height = layout.inner_box_size[1] * rect.height
 
     if not ref_piece_width * 0.7 <= piece_width <= ref_piece_width * 1.3:
-        print("inner_rect is too wide / skinny:", ref_piece_width, piece_width)
+        #print("inner_rect is too wide / skinny:", ref_piece_width, piece_width)
         #show_image(fill_image)
         return False
     if not ref_piece_height * 0.7 <= piece_height <= ref_piece_height * 1.3:
-        print("inner_rect is too short / tall", ref_piece_height, piece_height)
+        #print("inner_rect is too short / tall", ref_piece_height, piece_height)
         #show_image(fill_image)
         return False
     return True
@@ -258,21 +255,9 @@ def optimize_preview(arr, rect, layout):
     
     rect.multiply(1.0/BLOCKMATCH_SCALE_FACTOR)
     rect.round_to_int()
-    #debug_show_preview(red_area_resized, result)
+    #draw_and_show(red_area_resized, result)
     return rect
-    
-def show_image(image):
-    cv2.imshow("Image", image)
-    cv2.waitKey(0)
-
-def debug_show_preview(arr, rect):
-    if arr is None:
-        return
-    if isinstance(rect, Rect):
-        rect = rect.to_array()
-    arr = arr.copy()
-    cv2.rectangle(arr, (rect[0],rect[1]), (rect[2],rect[3]), (0, 0, 255), 1)
-    show_image(arr)
+   
 
     
 def debug_draw_layout(arr, layout, board_rect):

--- a/calibrate/autofindfield.py
+++ b/calibrate/autofindfield.py
@@ -142,9 +142,10 @@ def get_next_box(img, board_coord, suggested):
     """
     Iterates through all possible next box locations, starting with suggested one.
     """    
+    suggested_preview = suggested.preview
     layouts = list(PREVIEW_LAYOUTS.values())
-    layouts.remove(suggested)
-    layouts.insert(0,suggested)
+    layouts.remove(suggested_preview)
+    layouts.insert(0,suggested_preview)
 
     arr = convert_img_to_nparray(img)
     arr = convert_to_grayscale(arr)
@@ -152,6 +153,7 @@ def get_next_box(img, board_coord, suggested):
     # convert to nes pixels
     size = arr.shape[:]
     board_rect = Rect(*board_coord)
+    board_rect.sub_rect_perc(suggested.inner_box) #change it to be its subrect inplace.
 
     nes_pixel_x = board_rect.width / float(NES_PIXELS_BOARD_WIDTH) 
     nes_pixel_y = board_rect.height / float(NES_PIXELS_BOARD_HEIGHT)
@@ -160,7 +162,6 @@ def get_next_box(img, board_coord, suggested):
     for layout in layouts:
         left = board_rect.left + nes_pixel_x * layout.nes_px_offset[0]
         top = board_rect.top + nes_pixel_y * layout.nes_px_offset[1]
-        
         
         if layout.preview_type == PreviewLayout.HARDCODE: # e.g. ctm layout
             right = left + nes_pixel_x * layout.nes_px_size[0]

--- a/calibrate/autolayout.py
+++ b/calibrate/autolayout.py
@@ -27,6 +27,9 @@ class Layout(AbstractLayout):
         self.name = name
         self.fillpoint = fillpoint # fill point in relative screen coords (x,y)
         self.preview = preview # preview type
+    
+    def clone(self):
+        return Layout(self.name,self.fillpoint,self.preview,self.inner_box)
 
 #layout for preview
 class PreviewLayout(AbstractLayout):

--- a/calibrate/autolayout.py
+++ b/calibrate/autolayout.py
@@ -1,24 +1,10 @@
 ﻿"""
 Helper classes for autocalibration
 """
-class Layout:
-    def __init__(self, name, fillpoint, preview):
+class AbstractLayout:
+    def __init__(self, name, inner_box):
         self.name = name
-        self.fillpoint = fillpoint # fill point in relative screen coords (x,y)
-        self.preview = preview # preview type
-
-class PreviewLayout:    
-    TIGHT=1
-    STANDARD=2 # flood fill the box, then choose subset based on nes_px_size    
-    HARDCODE=3 # don't expand, just hardcode it.
-    
-    def __init__(self, name, nes_px_offset, nes_px_size, inner_box, preview_type, preview_size):
-        self.name = name
-        self.nes_px_offset = nes_px_offset #e.g. (90, 90)
-        self.nes_px_size = nes_px_size #e.g (42, 32)
-        self.inner_box = inner_box # e.g. (0.1, 0.1, 0.9, 0.9)
-        self.preview_type = preview_type
-        self.preview_size = preview_size #e.g. 1.0
+        self.inner_box = inner_box
 
     def recalc_sub_rect(self, new_sub_rect):
         """Given a new subrect in nes_pixels, calculates inner_box"""
@@ -33,6 +19,29 @@ class PreviewLayout:
     def inner_box_size(self):
         return [self.inner_box[2] - self.inner_box[0],
                 self.inner_box[3] - self.inner_box[1]]
+
+#layout for board
+class Layout(AbstractLayout):
+    def __init__(self, name, fillpoint, preview, inner_box=None):
+        super().__init__(name, inner_box)
+        self.name = name
+        self.fillpoint = fillpoint # fill point in relative screen coords (x,y)
+        self.preview = preview # preview type
+
+#layout for preview
+class PreviewLayout(AbstractLayout):
+    TIGHT=1
+    STANDARD=2 # flood fill the box, then choose subset based on nes_px_size    
+    HARDCODE=3 # don't expand, just hardcode it.
+    
+    def __init__(self, name, nes_px_offset, nes_px_size, inner_box, preview_type, preview_size):
+        self.name = name
+        self.nes_px_offset = nes_px_offset #e.g. (90, 90)
+        self.nes_px_size = nes_px_size #e.g (42, 32)
+        self.inner_box = inner_box # e.g. (0.1, 0.1, 0.9, 0.9)
+        self.preview_type = preview_type
+        self.preview_size = preview_size #e.g. 1.0
+
     
     @property
     def fillpoint(self):
@@ -98,15 +107,29 @@ PREVIEW_LAYOUTS = { # stencil, stock capture etc.
                     # "CTM": #4p
                   }
 
-
-LAYOUTS = {"STANDARD": Layout("Standard", (0.5,0.5), PREVIEW_LAYOUTS["STANDARD"]),
-           "RIGHT_SIDE": Layout("Standard", (0.75,0.5), PREVIEW_LAYOUTS["STANDARD"]),
-           "STENCIL": Layout("Stencil™", (0.3,0.5), PREVIEW_LAYOUTS["STANDARD"]),
-           "MOC_LEFT": Layout("MaxoutClub", (0.422,0.302), PREVIEW_LAYOUTS["MOC"]), #ctwc 2p
-           "MOC_RIGHT": Layout("MaxoutClub", (0.578,0.302), PREVIEW_LAYOUTS["MOC"]), #ctwc 2p
-           "MOC_TOPLEFT": Layout("MaxoutClub", (0.444,0.204), PREVIEW_LAYOUTS["MOC4pLeft"]), #ctwc 4p
-           "MOC_TOPRIGHT": Layout("MaxoutClub", (0.556,0.204), PREVIEW_LAYOUTS["MOC4pRight"]), #ctwc 4p
-           "MOC_BOTLEFT": Layout("MaxoutClub", (0.444,0.669), PREVIEW_LAYOUTS["MOC4pLeft"]), #ctwc 4p
-           "MOC_BOTRIGHT": Layout("MaxoutClub", (0.556,0.669), PREVIEW_LAYOUTS["MOC4pRight"]) #ctwc 4p
+FIELD_INNER_BOX = { 
+                    "Standard": (0.01,0.0,0.99,0.993), #4 nespix black bottom
+                    "MOC": (0.0,0.0,1.0,1.0) #fills entire area pretty much.
+                  }
+                    
+                    
+LAYOUTS = {"STANDARD": Layout("Standard", (0.5,0.5), 
+                              PREVIEW_LAYOUTS["STANDARD"], FIELD_INNER_BOX["Standard"]),
+           "RIGHT_SIDE": Layout("Standard", (0.75,0.5), 
+                              PREVIEW_LAYOUTS["STANDARD"], FIELD_INNER_BOX["Standard"]),
+           "STENCIL": Layout("Stencil™", (0.3,0.5), 
+                              PREVIEW_LAYOUTS["STANDARD"], FIELD_INNER_BOX["Standard"]),
+           "MOC_LEFT": Layout("MaxoutClub", (0.422,0.302), 
+                              PREVIEW_LAYOUTS["MOC"], FIELD_INNER_BOX["MOC"]), #ctwc 2p
+           "MOC_RIGHT": Layout("MaxoutClub", (0.578,0.302), 
+                              PREVIEW_LAYOUTS["MOC"], FIELD_INNER_BOX["MOC"]), #ctwc 2p
+           "MOC_TOPLEFT": Layout("MaxoutClub", (0.444,0.204), 
+                              PREVIEW_LAYOUTS["MOC4pLeft"], FIELD_INNER_BOX["MOC"]), #ctwc 4p
+           "MOC_TOPRIGHT": Layout("MaxoutClub", (0.556,0.204), 
+                              PREVIEW_LAYOUTS["MOC4pRight"], FIELD_INNER_BOX["MOC"]), #ctwc 4p
+           "MOC_BOTLEFT": Layout("MaxoutClub", (0.444,0.669), 
+                              PREVIEW_LAYOUTS["MOC4pLeft"],FIELD_INNER_BOX["MOC"]), #ctwc 4p
+           "MOC_BOTRIGHT": Layout("MaxoutClub", (0.556,0.669), 
+                              PREVIEW_LAYOUTS["MOC4pRight"],FIELD_INNER_BOX["MOC"]) #ctwc 4p
           }
 

--- a/calibrate/autolayout.py
+++ b/calibrate/autolayout.py
@@ -67,6 +67,8 @@ class PreviewLayout(AbstractLayout):
         we should only do template matching if we have heaps of 
         black space around. Otherwise we will fail horrendously
         """
+        if self.preview_type == self.HARDCODE:
+            return False
         perc = self.inner_box_size[0] * self.inner_box_size[1]
         return perc < 0.9
 

--- a/calibrate/blockmatch.py
+++ b/calibrate/blockmatch.py
@@ -261,6 +261,56 @@ def calc_new_rect(piece_type, rect):
 
     return rect
 
+def is_blackish(tuple):
+    return tuple[0] < 20 and tuple[1] < 20 and tuple[2] < 20
+
+
+def try_expand(arr, centre):
+    """
+    flood fills array from centre (y,x)
+    Returns rect class
+    """    
+    not_blackish = not is_blackish(arr[centre[0],centre[1]])
+    if not_blackish:
+        return Rect(centre[1],centre[0],centre[1],centre[0]), None
+
+    arr = np.array(arr, copy=True)
+    red = (0,0,255) #Blue green red
+    
+    centre = centre[1], centre[0] # opencv uses x,y
+    cv2.floodFill(arr, None, centre, newVal=red, loDiff=(5, 5, 5), upDiff=(5, 5, 5))
+
+    #show_image(arr)
+    
+    red_px = np.where(np.all(arr == red, axis=-1))
+    
+    y_values = list(red_px[0])
+    y_values.sort()
+    x_values = list(red_px[1])
+    x_values.sort()
+    
+    top, bot = y_values[0], y_values[-1]
+    left, right = x_values[0], x_values[-1]
+    
+    # todo: check percentage of red pixels, it better be at least 50%:
+    # reject if there's an overwhelming amount of non-red
+
+    return (Rect(left, top, right, bot), arr)
+
+def convert_to_grayscale(arr):
+    """
+    converts a BGR (technically RGB works too) image to grayscale RGB,
+    an rgb image where RGB channels are the same and are luminance.
+    """
+    # Convert image to grayscale, but in RGB format
+    gray = cv2.cvtColor(arr, cv2.COLOR_BGR2GRAY)
+    arr = np.zeros_like(arr)
+    arr[:,:,0] = gray
+    arr[:,:,1] = gray
+    arr[:,:,2] = gray
+    return arr
+
+
 # run as python -m calibrate.blockmatch -i "D:/dev/tetrisfish/Images/Callibration/templates"
 if __name__ == '__main__':
     # construct the argument parser and parse the arguments

--- a/calibrate/blockmatch.py
+++ b/calibrate/blockmatch.py
@@ -23,7 +23,7 @@ BLOCK_SIZE_PX = BLOCKMATCH_SCALE_FACTOR * NES_BLOCK_PIXELS
 # gaussian blur factor
 # we want to blur the minos so that the black borders disappear
 # therefore 4 nes pixels is about right.
-G_BLUR_FACTOR = int(5*math.ceil(BLOCKMATCH_SCALE_FACTOR)+1)
+G_BLUR_FACTOR = int(6*math.ceil(BLOCKMATCH_SCALE_FACTOR)+1)
 
 def show_image(image, text="image"):
     cv2.imshow(text, image)

--- a/calibrate/bounds.py
+++ b/calibrate/bounds.py
@@ -422,11 +422,9 @@ class BoundsPicker:
         if len(board_list) == 1:
             on_pick(board_list[0][0], board_list[0][1])
             return
-
         
         for index, item in enumerate(board_list):
-            print('constructing bounds')
-            board, _ = item
+            board, layout = item
             bound = Bounds(isNextBox, config)
             bound.setRect(board)
             bound.color = COLOR_CYCLE[index%len(COLOR_CYCLE)]
@@ -434,6 +432,7 @@ class BoundsPicker:
             bound.doNotDisplay = False
             bound.setDotColor(bound.color,bound.color)
             bound.set_board_index(index+1)
+            bound.setSubRect(layout.inner_box)
             self.bounds.append(bound)
 
 

--- a/calibrate/rect.py
+++ b/calibrate/rect.py
@@ -50,7 +50,14 @@ class Rect:
         """
         return (0 <= self.left <= self.right <= yx[1] and 
                 0 <= self.top <= self.bottom <= yx[0])
-           
+
+    def sub_rect_perc(self, sub_rect):
+        left = lerp(self.left, self.right, sub_rect[0])
+        top = lerp(self.top,self.bottom, sub_rect[1])
+        right = lerp(self.left,self.right, sub_rect[2])
+        bottom = lerp(self.top,self.bottom, sub_rect[3])
+        self.left, self.top, self.right, self.bottom = (left,top,right,bottom)
+
     def multiply(self, constant):
         self.left = self.left * constant
         self.top = self.top * constant
@@ -73,3 +80,6 @@ class Rect:
         ydist = (you[1] - point[1])
         result = xdist*xdist + ydist*ydist
         return result
+
+def lerp(small, big, value):
+    return small + (big-small) * value


### PR DESCRIPTION
Added new subrect feature for identifying the "true" bottom of the field. This requires at least 2-3 NES blocks on the bottom of the field; it simply scans upwards, then adjusts the inner_rect to match.
![image](https://user-images.githubusercontent.com/6406312/147814504-2642b44c-85e3-4ef4-a7c5-3ef3246015b9.png)

I also realised there could be some accuracy improvements by using inner_rect rather than the full rect for determining where the preview piece is; i shall do another PR for that later.